### PR TITLE
@definitelytyped/utils: move @types/node dep to devDependencies

### DIFF
--- a/packages/header-parser/package.json
+++ b/packages/header-parser/package.json
@@ -27,5 +27,8 @@
     "@definitelytyped/utils": "^0.0.16",
     "@types/parsimmon": "^1.10.1",
     "parsimmon": "^1.13.0"
+  },
+  "devDependencies": {
+    "@types/parsimmon": "^1.10.1"
   }
 }

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -25,7 +25,8 @@
 		"@types/node": {
 			"version": "12.12.29",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.29.tgz",
-			"integrity": "sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ=="
+			"integrity": "sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ==",
+			"dev": true
 		},
 		"@types/tar-stream": {
 			"version": "2.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,12 +23,12 @@
     "url": "https://github.com/DefinitelyTyped/tools/issues"
   },
   "dependencies": {
-    "@types/node": "^12.12.29",
     "charm": "^1.0.2",
     "fs-extra": "^8.1.0",
     "tar-stream": "^2.1.0"
   },
   "devDependencies": {
+    "@types/node": "^12.12.29",
     "@types/charm": "^1.0.1",
     "@types/fs-extra": "^8.1.0",
     "@types/tar-stream": "^2.1.0"


### PR DESCRIPTION
Improves compatibility for dependents that have differing global declarations for `require`.

The dependency on `@types/node` causes that package to be installed into `node_modules/` of any dependent.
This is problematic for non-node projects with own, differing global declarations of `require`, as it will trigger TypeScript errors TS2300 (Duplicate identifier 'require') or TS2403 (Subsequent variable declarations must have the same type).

Moving the dependency to `devDependencies` continues to make npm scripts pass successfully (`test` & `build`), and `tsc --noEmit` also runs successfully.